### PR TITLE
Implement Centralized 'from' Configuration and Model-Driven 'to' in Panacea SMS in Panacea SMS Channel

### DIFF
--- a/src/PanaceaMobileSms.php
+++ b/src/PanaceaMobileSms.php
@@ -57,6 +57,17 @@ class PanaceaMobileSms
     }
 
     /**
+     * Checks if 'to' array is empty.
+     *
+     * @param  string  $to
+     * @return $this
+     */
+    public function isToEmpty()
+    {
+        return empty($this->to);
+    }
+
+    /**
      * Add SMS sender name.
      *
      * @param  string  $from

--- a/src/PanaceaMobileSms.php
+++ b/src/PanaceaMobileSms.php
@@ -81,6 +81,17 @@ class PanaceaMobileSms
     }
 
     /**
+     * Checks if 'to' array is empty.
+     *
+     * @param  string  $to
+     * @return $this
+     */
+    public function isFromNull()
+    {
+        return is_null($this->from);
+    }
+
+    /**
      * Add many SMS recipients.
      *
      * @param  array  $to

--- a/src/PanaceaMobileSms.php
+++ b/src/PanaceaMobileSms.php
@@ -59,8 +59,7 @@ class PanaceaMobileSms
     /**
      * Checks if 'to' array is empty.
      *
-     * @param  string  $to
-     * @return $this
+     * @return bool
      */
     public function isToEmpty()
     {
@@ -81,10 +80,9 @@ class PanaceaMobileSms
     }
 
     /**
-     * Checks if 'to' array is empty.
+     * Checks if 'from' property is null.
      *
-     * @param  string  $to
-     * @return $this
+     * @return bool
      */
     public function isFromNull()
     {

--- a/src/PanaceaMobileSmsChannel.php
+++ b/src/PanaceaMobileSmsChannel.php
@@ -34,7 +34,7 @@ class PanaceaMobileSmsChannel
             $message->to($to);
         }
 
-        if (is_null($message->from) && !is_null($from)) {
+        if ($message->isFromNull() && !is_null($from)) {
             $message->from($from);
         }
 

--- a/src/PanaceaMobileSmsChannel.php
+++ b/src/PanaceaMobileSmsChannel.php
@@ -3,6 +3,7 @@
 namespace Emotality\Panacea;
 
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Config;
 
 class PanaceaMobileSmsChannel
 {
@@ -16,14 +17,27 @@ class PanaceaMobileSmsChannel
      */
     public function send($notifiable, Notification $notification)
     {
+        $to = $notifiable->routeNotificationFor('panacea', $notification);
+        $from = Config::get('panacea.from');
+
         if (method_exists($notification, 'toPanacea')) {
-            $notification->toPanacea($notifiable)->send();
+            $message = $notification->toPanacea($notifiable);
         } elseif (method_exists($notification, 'toSms')) {
-            $notification->toSms($notifiable)->send();
+            $message = $notification->toSms($notifiable);
         } elseif (method_exists($notification, 'sms')) {
-            $notification->sms($notifiable)->send();
+            $message = $notification->sms($notifiable);
         } else {
-            throw new PanaceaException('toSms() function not found in Notification to send SMS.');
+            throw new PanaceaException('Appropriate method to format the SMS message not found in Notification.');
         }
+
+        if ($message->isToEmpty() && !is_null($to)) {
+            $message->to($to);
+        }
+
+        if (is_null($message->from) && !is_null($from)) {
+            $message->from($from);
+        }
+
+        $message->send();
     }
 }


### PR DESCRIPTION
The key changes I'm proposing allow for a default 'from' number to be specified once in the configuration and for the 'to' number to be dynamically determined from the notifiable model, without the need to specify these in every notification.

Modifications:

1. The send method in PanaceaMobileSmsChannel now retrieves the 'from' number from the configuration file (config/panacea.php) if it's not set in the message object.
2. It determines the 'to' number from the notifiable entity using a routeNotificationForPanacea method, which you should define in your notifiable models (e.g., User). This method returns the appropriate phone number field, (in the example below 'primary_phone').

_App\Models\User.php_


```
/**
 * Route notifications for the Panacea channel.
 *
 * @param  \Illuminate\Notifications\Notification  $notification
 * @return string
 */
public function routeNotificationForPanacea($notification)
{
    return $this->primary_phone;
}
```

3. Conditional checks have been introduced to ensure that default values for 'to' and 'from' are applied only when they haven't been specified beforehand.

Now in most notifications, you no longer need to set the 'to' and 'from' numbers explicitly, and the 'to' number can be set dynamically.

**Before**

```
public function toPanacea($notifiable)
{
    return (new PanaceaMobileSms())
        ->to($notifiable->mobile)
        ->from('YourAppName')
        ->message("Your message content");
}
```

**After**

```
public function toPanacea($notifiable)
{
    return (new PanaceaMobileSms)
        ->message("Your message content");
}
```

The implementation was inspired by the similar design of the [laravel/vonage-notification-channel ](https://github.com/laravel/vonage-notification-channel) package.